### PR TITLE
Fix for name error AUTH not defined

### DIFF
--- a/v2api/query_v2_api.py
+++ b/v2api/query_v2_api.py
@@ -28,6 +28,7 @@ def get_auth_from_env_file(filename: str='.env'):
             
     return auth
 
+AUTH=get_auth_from_env_file()
 
 pp = PrettyPrinter()
 


### PR DESCRIPTION
get_auth_from_env_file() returns auth then subsequent function have default arguement auth=AUTH, I added AUTH=get_auth_from_env_file() so that we don't get an error because AUTH isn't defined